### PR TITLE
Fix: Support translation functions with multiple arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,14 @@ All notable changes to the "transl8" extension will be documented in this file.
 
 ---
 
-## [1.1.1] - 2025-09-04
+## [1.2.1] - 2025-09-04
 ### Fixed
 
 - Hover previews for translation keys now correctly appear on function calls that include additional arguments, such as interpolation objects (e.g., `t('greeting', { name: 'World' })`).
 
 
-## [1.1.0] - 2025-09-04
+## [1.2.0] - 2025-09-04
 
 ### Added
 - **Live Diagnostics:** Implemented real-time checking for missing translation keys.
 - **Problem Reporting:** Missing keys are now automatically underlined and added to the VS Code "Problems" panel for easy tracking and review. ✅
-
----
-
-## [1.0.0]
-
-- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "transl8" extension will be documented in this file.
 
 ---
 
+## [1.1.1] - 2025-09-04
+### Fixed
+
+- Hover previews for translation keys now correctly appear on function calls that include additional arguments, such as interpolation objects (e.g., `t('greeting', { name: 'World' })`).
+
+
 ## [1.1.0] - 2025-09-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transl8",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transl8",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transl8",
-  "version": "0.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transl8",
-      "version": "0.0.1",
+      "version": "1.2.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "transl8",
   "displayName": "Transl8",
   "description": "Manage translations directly within your code editor.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.103.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "transl8",
   "displayName": "Transl8",
   "description": "Manage translations directly within your code editor.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "engines": {
     "vscode": "^1.103.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "transl8",
   "displayName": "Transl8",
   "description": "Manage translations directly within your code editor.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "vscode": "^1.103.0"
   },

--- a/src/transl8/diagnostics.ts
+++ b/src/transl8/diagnostics.ts
@@ -25,7 +25,7 @@ export function updateDiagnostics(document: vscode.TextDocument): void {
     .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|");
   const keyRegex = new RegExp(
-    `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*\\)`,
+    `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
     "g"
   );
 

--- a/src/transl8/hoverProvider.ts
+++ b/src/transl8/hoverProvider.ts
@@ -20,7 +20,7 @@ export function registerHoverProvider(): vscode.Disposable {
           .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
           .join("|");
         const keyRegex = new RegExp(
-          `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*\\)`,
+          `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
           "g"
         );
 


### PR DESCRIPTION
### fix(hover): Support translation functions with multiple arguments


### Description

This pull request fixes a bug where the hover preview for translation keys was not appearing if the translation function call included more than one argument.

The hover provider worked correctly for simple cases like `t('app.title')` but would fail for more complex calls that included an interpolation object, such as `t('app.greeting', { name: 'User' })`.

### Solution

The root cause was an overly strict regular expression that was used to find translation keys. It expected a closing parenthesis `)` immediately after the key's string literal, which failed when a comma `,` was present.

The regex has been updated to be more flexible, correctly capturing the key regardless of any subsequent arguments in the function call.
