### PR TITLE
### fix: Improve regex precision to avoid false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-All notable changes to the "transl8" extension will be documented in this file.
 
 ---
 
+## [1.2.4] - 2025-09-04
+
+### Fixed
+
+- Improved the accuracy of the hover provider to prevent it from incorrectly activating on functions that are not translation functions. For example, it will no longer trigger on `split('.')` if your translation function is named `t`.
+
 ## [1.2.1] - 2025-09-04
+
 ### Fixed
 
 - Hover previews for translation keys now correctly appear on function calls that include additional arguments, such as interpolation objects (e.g., `t('greeting', { name: 'World' })`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transl8",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transl8",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "transl8",
   "displayName": "Transl8",
   "description": "Manage translations directly within your code editor.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "vscode": "^1.103.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "transl8",
   "displayName": "Transl8",
   "description": "Manage translations directly within your code editor.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "engines": {
     "vscode": "^1.103.0"
   },

--- a/src/transl8/diagnostics.ts
+++ b/src/transl8/diagnostics.ts
@@ -25,7 +25,7 @@ export function updateDiagnostics(document: vscode.TextDocument): void {
     .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|");
   const keyRegex = new RegExp(
-    `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
+    `(?<!\\w)(?:${functionNamesRegexPart})\\b\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
     "g"
   );
 

--- a/src/transl8/hoverProvider.ts
+++ b/src/transl8/hoverProvider.ts
@@ -20,7 +20,7 @@ export function registerHoverProvider(): vscode.Disposable {
           .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
           .join("|");
         const keyRegex = new RegExp(
-          `(?:${functionNamesRegexPart})\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
+          `(?<!\\w)(?:${functionNamesRegexPart})\\b\\s*\\(\\s*['"]([^'"]+)['"]\\s*[,)]`,
           "g"
         );
 


### PR DESCRIPTION
## Description
This pull request resolves a bug where the hover provider for translation keys would incorrectly activate on functions that were not the intended translation function.

This occurred if an unrelated function name contained the target translation function's name as a substring. For example, if the configured translation function was t(), the provider would incorrectly trigger on the t in field.path.split('.'). This led to unwanted hover popups and incorrect behaviour.

## Solution
The regular expression used for key detection has been made more precise. By adding word boundaries ((?<!\w) and \b), the regex now ensures it only matches the specified function names as whole words.

This change prevents the engine from matching substrings within other identifiers, eliminating the false positives without affecting the detection of legitimate translation keys.
