### PR TITLE
Feat: Quickfix for missing translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
         "title": "Transl8: Edit Translation"
       }
     ],
+    "menus": {
+    "commandPalette": [
+      {
+        "command": "lifeordev.transl8.editTranslation",
+        "when": "false" 
+      }
+    ]
+    },
     "configuration": {
       "title": "Transl8 Configuration",
       "properties": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,19 +3,18 @@ import { registerEditTranslationCommand } from "./transl8/commands";
 import { registerHoverProvider } from "./transl8/hoverProvider";
 import { registerCompletionProvider } from "./transl8/completionProvider";
 import { updateDiagnostics, diagnosticCollection } from "./transl8/diagnostics";
+import { Transl8QuickFixProvider } from "./transl8/quickFixProvider";
 
 export function activate(context: vscode.ExtensionContext) {
   console.log("Transl8 extension is now active!");
 
-  // Register all features. They are now self-sufficient and will get
-  // configuration based on the active document.
   const editCommand = registerEditTranslationCommand();
   const hoverProvider = registerHoverProvider();
   const completionProvider = registerCompletionProvider();
 
-  // Add all disposables to the extension's subscriptions.
   context.subscriptions.push(editCommand, hoverProvider, completionProvider);
 
+  // **********************************
   // Error Diagnostics
   let debounceTimer: NodeJS.Timeout;
 
@@ -49,6 +48,21 @@ export function activate(context: vscode.ExtensionContext) {
       diagnosticCollection.delete(doc.uri);
     })
   );
+
+  // **********************************
+  // QuickFix
+  for (const lang of ["javascript", "typescript", "vue"]) {
+    context.subscriptions.push(
+      vscode.languages.registerCodeActionsProvider(
+        { scheme: "file", language: lang },
+        new Transl8QuickFixProvider(),
+        {
+          providedCodeActionKinds:
+            Transl8QuickFixProvider.providedCodeActionKinds,
+        }
+      )
+    );
+  }
 }
 
 export function deactivate() {}

--- a/src/transl8/diagnostics.ts
+++ b/src/transl8/diagnostics.ts
@@ -47,6 +47,7 @@ export function updateDiagnostics(document: vscode.TextDocument): void {
         vscode.DiagnosticSeverity.Error
       );
 
+      diagnostic.code = "no-translation";
       diagnostic.source = "Transl8";
       diagnostics.push(diagnostic);
     }

--- a/src/transl8/quickFixProvider.ts
+++ b/src/transl8/quickFixProvider.ts
@@ -1,0 +1,57 @@
+import * as vscode from "vscode";
+
+/**
+ * Provides Quick Fix actions for 'no-translation' diagnostics.
+ */
+export class Transl8QuickFixProvider implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [
+    vscode.CodeActionKind.QuickFix,
+  ];
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.CodeAction[]> {
+    const actions: vscode.CodeAction[] = [];
+
+    // Find diagnostics that this provider can fix
+    const relevantDiagnostics = context.diagnostics.filter(
+      (diagnostic) => diagnostic.code === "no-translation"
+    );
+
+    relevantDiagnostics.forEach((diagnostic) => {
+      actions.push(this.createAddTranslationCommand(document, diagnostic));
+    });
+
+    return actions;
+  }
+
+  private createAddTranslationCommand(
+    document: vscode.TextDocument,
+    diagnostic: vscode.Diagnostic
+  ): vscode.CodeAction {
+    // The text within the diagnostic's range is our translation key
+    const key = document.getText(diagnostic.range);
+
+    // Create the CodeAction that will be shown as the Quick Fix
+    const action = new vscode.CodeAction(
+      "Add Translation...",
+      vscode.CodeActionKind.QuickFix
+    );
+
+    // Set the command that will be executed when the user clicks the Quick Fix
+    action.command = {
+      command: "lifeordev.transl8.editTranslation", // Your command ID
+      title: "Add a new translation",
+      tooltip: "This will open an input to add a new translation for this key.",
+      arguments: [key, document.uri.toString()], // Pass the key and URI
+    };
+
+    // Mark this action as the preferred one for this diagnostic
+    action.isPreferred = true;
+
+    return action;
+  }
+}


### PR DESCRIPTION
## Description
This pull request introduces a major usability improvement by replacing the simple diagnostic error for missing translation keys with an interactive Quick Fix. 💡

Previously, when a key was not found, the extension would only highlight the error. Now, users will see a lightbulb icon next to the error, allowing them to take immediate action. Clicking the Quick Fix and selecting "Add Translation..." directly triggers the editTranslation command, pre-filling the key and file context.

This creates a much smoother and more intuitive workflow for adding new translations.

Key Changes:

Transl8QuickFixProvider: A new CodeActionProvider has been implemented to provide the "Add Translation" action for diagnostics with the code 'no-translation'.

diagnostics.ts: Diagnostics for missing keys have been updated to include the necessary code and now display a simpler, more direct error message.

package.json: The editTranslation command has been hidden from the Command Palette by adding a menus contribution with "when": "false". This ensures the command is only triggered contextually (e.g., by our Quick Fix), where it has the required key and file URI.